### PR TITLE
refactor: update native sdk version and add default parameter for debug

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -117,7 +117,7 @@ dependencies {
     implementation 'com.facebook.react:react-android:0.80.0'
 
     // Linkrunner SDK 
-    implementation "io.linkrunner:android-sdk:2.1.4"
+    implementation "io.linkrunner:android-sdk:2.1.5"
 
     // Kotlin standard libraries - use stable versions
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,7 +33,7 @@ class Linkrunner {
     return package_version;
   }
 
-  async init(token: string, secretKey?: string, keyId?: string, debug?: boolean) {
+  async init(token: string, secretKey?: string, keyId?: string, debug: boolean=false) {
     if (!token) {
       console.error('Linkrunner needs your project token to initialize!');
       return;


### PR DESCRIPTION
- Set default value for debug.
- An undefined value for debug led to an error in the native Android SDK wrapper, which expected the debug value to be either true or false, but not undefined.