### PR TITLE
chore: linkrunner-android version update and koin removal

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -117,7 +117,7 @@ dependencies {
     implementation 'com.facebook.react:react-android:0.80.0'
 
     // Linkrunner SDK 
-    implementation "io.linkrunner:android-sdk:2.1.5"
+    implementation "io.linkrunner:android-sdk:2.2.0"
 
     // Kotlin standard libraries - use stable versions
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
@@ -137,9 +137,6 @@ dependencies {
     // Coroutines - matching Android SDK
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.8.0'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.8.0'
-
-    // Dependency Injection - matching Android SDK
-    implementation 'io.insert-koin:koin-android:3.5.3'
 
     // Google Play Services - matching Android SDK exactly
     implementation 'com.google.android.gms:play-services-ads-identifier:18.0.1'


### PR DESCRIPTION
- update Linkrunner SDK to version 2.2.0 and remove unused Koin dependency

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Linkrunner SDK to version 2.2.0.
  * Removed an unused dependency to streamline the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->