### PR TITLE
chore: remove unused dependencies and update native android version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -117,7 +117,7 @@ dependencies {
     implementation 'com.facebook.react:react-android:0.80.0'
 
     // Linkrunner SDK 
-    implementation "io.linkrunner:android-sdk:2.2.0"
+    implementation "io.linkrunner:android-sdk:3.0.1"
 
     // Kotlin standard libraries - use stable versions
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,13 +8,7 @@
       "name": "rn-linkrunner",
       "version": "2.3.0",
       "license": "MIT",
-      "dependencies": {
-        "@react-native-async-storage/async-storage": "^2.0.0",
-        "@react-native-community/netinfo": "^11.3.2",
-        "@sparkfabrik/react-native-idfa-aaid": "^1.2.0",
-        "react-native-device-info": "^10.12.0",
-        "react-native-play-install-referrer": "^1.1.8"
-      },
+      "dependencies": {},
       "devDependencies": {
         "@commitlint/config-conventional": "^17.0.2",
         "@evilmartians/lefthook": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -138,11 +138,5 @@
       "typescript"
     ]
   },
-  "dependencies": {
-    "@react-native-async-storage/async-storage": "^2.0.0",
-    "@react-native-community/netinfo": "^11.3.2",
-    "@sparkfabrik/react-native-idfa-aaid": "^1.2.0",
-    "react-native-device-info": "^10.12.0",
-    "react-native-play-install-referrer": "^1.1.8"
-  }
+  "dependencies": {}
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,6 @@
 import { NativeModules, Platform } from 'react-native';
 import type { AttributionData, IntegrationData, UserData } from './types';
 import packageJson from '../package.json';
-import DeviceInfo from 'react-native-device-info';
 
 const LINKING_ERROR =
   `The package 'rn-linkrunner' doesn't seem to be linked. Make sure: \n\n` +
@@ -16,17 +15,12 @@ if (!LinkrunnerSDKModule) {
 }
 
 const package_version = packageJson.version;
-const app_version: string = DeviceInfo.getVersion();
 
 class Linkrunner {
   private token: string | null;
 
   constructor() {
     this.token = null;
-  }
-
-  getAppVersion() {
-    return app_version;
   }
 
   getPackageVersion() {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Upgraded to Linkrunner Android SDK 3.0.1 for the latest capabilities and improvements.
- Refactor
  - Removed the getAppVersion() method from the public API; app version retrieval is no longer provided by this SDK.
- Chores
  - Cleaned up runtime dependencies; removed unused packages from the app’s dependency list to reduce footprint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->