### PR TITLE
chore: bump native android sdk to 3.8.1 (rn-linkrunner 2.10.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.10.1] - 2026-05-07
+
+### Changed
+
+- Bumped native Android SDK to `io.linkrunner:android-sdk:3.8.1` — token, signature key id, and signature secret key are now encrypted at rest in SharedPreferences using AES-256-GCM with a hardware-backed AndroidKeyStore key (StrongBox when available); legacy plaintext keys from prior versions are wiped atomically on the first `init()` after upgrade
+
 ## [2.10.0] - 2026-04-03
 
 ### Added

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -116,7 +116,7 @@ dependencies {
     implementation 'com.facebook.react:react-android:0.80.0'
 
     // Linkrunner SDK 
-    implementation "io.linkrunner:android-sdk:3.8.0"
+    implementation "io.linkrunner:android-sdk:3.8.1"
 
     // Kotlin standard libraries - use stable versions
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-linkrunner",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "description": "React Native Package for linkrunner",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
## Summary

- Bump `io.linkrunner:android-sdk` from `3.8.0` to `3.8.1` in `android/build.gradle`
- Bump `rn-linkrunner` from `2.10.0` to `2.10.1` in `package.json`
- Add `2.10.1` entry to `CHANGELOG.md`

The native SDK 3.8.1 stores `token`, `keyId`, and `secretKey` encrypted-at-rest with AES-256-GCM backed by AndroidKeyStore (StrongBox when available), replacing the previous plaintext SharedPreferences storage. Migration from legacy plaintext keys to the new V2 encrypted keys happens atomically on the first `init()` after upgrade — no caller change required.

Equivalent change in the Flutter SDK: RathodDarshil/linkrunner#31.

## Test plan

- [ ] Smoke test in the RN sandbox: `init` → `signup` → `capturePayment` → `trackEvent` → `handleDeeplink` flow through to `api.linkrunner.io` with HTTP 202
- [ ] Verify on-device that `io.linkrunner.sdk_prefs` SharedPreferences contains the V2 encrypted keys (`linkrunner_token_v2`, `linkrunner_key_id_v2`, `linkrunner_secret_key_v2`) and that the legacy plaintext keys are absent after `init`
- [ ] Upgrade-path test: install an older build that wrote plaintext keys, then upgrade to this build and confirm legacy keys are wiped on the first `init()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)