### PR TITLE
feat: expose ad-network ids/names in attribution data [LIN-1581]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.1] - 2026-07-09
+
+### Added
+
+- Exposed ad-network attribution fields in attribution data: `adNetworkCampaignId`, `adSetId`, `adSetName`, `adCreativeId`, `adCreativeName`.
+
+### Changed
+
+- Bumped native Android SDK to `io.linkrunner:android-sdk:4.0.1`
+- Bumped native iOS SDK to `LinkrunnerKit 4.0.1`
+
 ## [3.0.0] - 2026-06-30
 
 ### Changed

--- a/LinkrunnerSDK.podspec
+++ b/LinkrunnerSDK.podspec
@@ -19,5 +19,5 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.dependency "React"
-  s.dependency 'LinkrunnerKit', '3.10.0'
+  s.dependency 'LinkrunnerKit', '3.11.0'
 end

--- a/LinkrunnerSDK.podspec
+++ b/LinkrunnerSDK.podspec
@@ -19,5 +19,5 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.dependency "React"
-  s.dependency 'LinkrunnerKit', '3.11.0'
+  s.dependency 'LinkrunnerKit', '3.12.0'
 end

--- a/LinkrunnerSDK.podspec
+++ b/LinkrunnerSDK.podspec
@@ -19,5 +19,5 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.dependency "React"
-  s.dependency 'LinkrunnerKit', '4.0.0'
+  s.dependency 'LinkrunnerKit', '4.0.1'
 end

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -116,7 +116,7 @@ dependencies {
     implementation 'com.facebook.react:react-android:0.80.0'
 
     // Linkrunner SDK 
-    implementation "io.linkrunner:android-sdk:3.9.0"
+    implementation "io.linkrunner:android-sdk:3.10.0"
 
     // Kotlin standard libraries - use stable versions
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -116,7 +116,7 @@ dependencies {
     implementation 'com.facebook.react:react-android:0.80.0'
 
     // Linkrunner SDK 
-    implementation "io.linkrunner:android-sdk:3.8.1"
+    implementation "io.linkrunner:android-sdk:3.9.0"
 
     // Kotlin standard libraries - use stable versions
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -116,7 +116,7 @@ dependencies {
     implementation 'com.facebook.react:react-android:0.80.0'
 
     // Linkrunner SDK 
-    implementation "io.linkrunner:android-sdk:4.0.0"
+    implementation "io.linkrunner:android-sdk:4.0.1"
 
     // Kotlin standard libraries - use stable versions
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"

--- a/android/src/main/java/io/linkrunner/LinkrunnerModule.kt
+++ b/android/src/main/java/io/linkrunner/LinkrunnerModule.kt
@@ -329,7 +329,12 @@ class LinkrunnerModule(private val reactContext: ReactApplicationContext) : Reac
                                 campaignDataMap.putString("groupName", campaignData.groupName)
                                 campaignDataMap.putString("assetName", campaignData.assetName)
                                 campaignDataMap.putString("assetGroupName", campaignData.assetGroupName)
-                                
+                                campaignDataMap.putString("adNetworkCampaignId", campaignData.adNetworkCampaignId)
+                                campaignDataMap.putString("adSetId", campaignData.adSetId)
+                                campaignDataMap.putString("adSetName", campaignData.adSetName)
+                                campaignDataMap.putString("adCreativeId", campaignData.adCreativeId)
+                                campaignDataMap.putString("adCreativeName", campaignData.adCreativeName)
+
                                 response.putMap("campaignData", campaignDataMap)
                             }
                         }

--- a/android/src/main/java/io/linkrunner/utils/ModelConverter.kt
+++ b/android/src/main/java/io/linkrunner/utils/ModelConverter.kt
@@ -74,7 +74,27 @@ object ModelConverter {
         data.assetGroupName?.let { assetGroupName ->
             map.putString("assetGroupName", assetGroupName)
         }
-        
+
+        data.adNetworkCampaignId?.let { adNetworkCampaignId ->
+            map.putString("adNetworkCampaignId", adNetworkCampaignId)
+        }
+
+        data.adSetId?.let { adSetId ->
+            map.putString("adSetId", adSetId)
+        }
+
+        data.adSetName?.let { adSetName ->
+            map.putString("adSetName", adSetName)
+        }
+
+        data.adCreativeId?.let { adCreativeId ->
+            map.putString("adCreativeId", adCreativeId)
+        }
+
+        data.adCreativeName?.let { adCreativeName ->
+            map.putString("adCreativeName", adCreativeName)
+        }
+
         data.assetName?.let { assetName ->
             map.putString("assetName", assetName)
         }
@@ -164,7 +184,12 @@ object ModelConverter {
                 campaignDataMap.putString("groupName", campaignData.groupName)
                 campaignDataMap.putString("assetName", campaignData.assetName)
                 campaignDataMap.putString("assetGroupName", campaignData.assetGroupName)
-                
+                campaignDataMap.putString("adNetworkCampaignId", campaignData.adNetworkCampaignId)
+                campaignDataMap.putString("adSetId", campaignData.adSetId)
+                campaignDataMap.putString("adSetName", campaignData.adSetName)
+                campaignDataMap.putString("adCreativeId", campaignData.adCreativeId)
+                campaignDataMap.putString("adCreativeName", campaignData.adCreativeName)
+
                 map.putMap("campaignData", campaignDataMap)
             }
         }

--- a/ios/LinkrunnerSDK.swift
+++ b/ios/LinkrunnerSDK.swift
@@ -218,6 +218,26 @@ class LinkrunnerSDK: NSObject {
                     campaignDataMap["assetGroupName"] = assetGroupName
                     campaignDataMap["asset_group_name"] = assetGroupName
                 }
+                if let adNetworkCampaignId = campaignData.adNetworkCampaignId {
+                    campaignDataMap["adNetworkCampaignId"] = adNetworkCampaignId
+                    campaignDataMap["ad_network_campaign_id"] = adNetworkCampaignId
+                }
+                if let adSetId = campaignData.adSetId {
+                    campaignDataMap["adSetId"] = adSetId
+                    campaignDataMap["ad_set_id"] = adSetId
+                }
+                if let adSetName = campaignData.adSetName {
+                    campaignDataMap["adSetName"] = adSetName
+                    campaignDataMap["ad_set_name"] = adSetName
+                }
+                if let adCreativeId = campaignData.adCreativeId {
+                    campaignDataMap["adCreativeId"] = adCreativeId
+                    campaignDataMap["ad_creative_id"] = adCreativeId
+                }
+                if let adCreativeName = campaignData.adCreativeName {
+                    campaignDataMap["adCreativeName"] = adCreativeName
+                    campaignDataMap["ad_creative_name"] = adCreativeName
+                }
                 if let assetName = campaignData.assetName {
                     campaignDataMap["assetName"] = assetName
                     campaignDataMap["asset_name"] = assetName

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -12,7 +12,7 @@ abstract_target 'LinkrunnerSDK' do
   # Pods for LinkrunnerSDK
   
   # Add the linkrunner-ios-sdk dependency
-    pod 'LinkrunnerKit', '3.11.0'
+    pod 'LinkrunnerKit', '3.12.0'
 
   
   # Add any other dependencies your SDK needs here

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -12,7 +12,7 @@ abstract_target 'LinkrunnerSDK' do
   # Pods for LinkrunnerSDK
   
   # Add the linkrunner-ios-sdk dependency
-    pod 'LinkrunnerKit', '3.10.0'
+    pod 'LinkrunnerKit', '3.11.0'
 
   
   # Add any other dependencies your SDK needs here

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -12,7 +12,7 @@ abstract_target 'LinkrunnerSDK' do
   # Pods for LinkrunnerSDK
   
   # Add the linkrunner-ios-sdk dependency
-    pod 'LinkrunnerKit', '3.12.0'
+    pod 'LinkrunnerKit', '4.0.1'
 
   
   # Add any other dependencies your SDK needs here

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rn-linkrunner",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rn-linkrunner",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "license": "MIT",
       "devDependencies": {
         "@commitlint/config-conventional": "^17.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-linkrunner",
-  "version": "2.10.1",
+  "version": "2.11.0",
   "description": "React Native Package for linkrunner",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-linkrunner",
-  "version": "2.11.0",
+  "version": "2.12.0",
   "description": "React Native Package for linkrunner",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-linkrunner",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "React Native Package for linkrunner",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,6 +40,11 @@ export interface CampaignData {
   groupName?: string;
   assetName?: string;
   assetGroupName?: string;
+  adNetworkCampaignId?: string | null;
+  adSetId?: string | null;
+  adSetName?: string | null;
+  adCreativeId?: string | null;
+  adCreativeName?: string | null;
 }
 
 export interface AttributionData {


### PR DESCRIPTION
Adds the 5 new attribution fields the backend now returns in `getAttributionData → campaign_data` to this SDK's types **and native↔JS bridges**: `adNetworkCampaignId`, `adSetId`, `adSetName`, `adCreativeId`, `adCreativeName` (optional / nullable). Also bumps the native Linkrunner SDK dependency pins to **android `3.10.0`** / **iOS `LinkrunnerKit 3.12.0`**.

**Version:** 2.11.0 → **2.12.0**
**Linear:** LIN-1581

> ⚠️ **Do not merge/release until the native SDKs are published first:** linkrunner-android `3.10.0` and linkrunner-ios (LinkrunnerKit) `3.12.0` — otherwise the native dependency won't resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Attribution data now includes additional optional campaign fields: ad network campaign ID, ad set ID/name, and ad creative ID/name across Android, iOS, and TypeScript.
* **Bug Fixes**
  * iOS attribution responses now also include legacy snake_case campaign keys when the corresponding values are present.
* **Chores**
  * Updated native SDK dependencies (iOS LinkrunnerKit and Android android-sdk) and bumped the package version to 3.0.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->