### PR TITLE
Bump Android SDK to 4.0.2 for LIN-1946

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.2] - 2026-07-23
+
+### Fixed
+
+- Bumped the native Android SDK to `io.linkrunner:android-sdk:4.0.2` to prevent signup from sending an empty install instance ID when it runs concurrently with initialization.
+
 ## [3.0.1] - 2026-07-09
 
 ### Added

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -116,7 +116,7 @@ dependencies {
     implementation 'com.facebook.react:react-android:0.80.0'
 
     // Linkrunner SDK 
-    implementation "io.linkrunner:android-sdk:4.0.1"
+    implementation "io.linkrunner:android-sdk:4.0.2"
 
     // Kotlin standard libraries - use stable versions
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rn-linkrunner",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rn-linkrunner",
-      "version": "3.0.1",
+      "version": "3.0.2",
       "license": "MIT",
       "devDependencies": {
         "@commitlint/config-conventional": "^17.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-linkrunner",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "React Native Package for linkrunner",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
Linear: https://linear.app/linkrunner/issue/LIN-1946/android-sdk-signup-can-send-empty-install-instance-id-before

## Summary

- bump `rn-linkrunner` from `3.0.1` to `3.0.2`
- bump the native Android dependency from `4.0.1` to `4.0.2`
- document the Android signup/install instance ID fix

## Validation

- package preparation completed successfully
- package version and lockfile consistency checks passed
- `git diff --check` passed

Android dependency resolution is deferred until `io.linkrunner:android-sdk:4.0.2` is published.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where signup could send an empty install ID when performed during app initialization.
  * Updated the Android SDK to improve install ID handling.

* **Release**
  * Updated the package version to **3.0.2**.
  * Added release documentation dated **July 23, 2026**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->