### PR TITLE
feat: support TCF consent collection on Android [LIN-2078]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.2.0] - 2026-07-30
+
+### Added
+
+- `enableTCFConsentCollection(enabled)` now works on Android too, matching iOS. The native Android SDK reads the CMP's standard `IABTCF_*` keys from the default SharedPreferences and applies the same Google TCF purpose mapping; anything set explicitly with `setConsent` still wins, per signal.
+
+### Changed
+
+- Bumped native Android SDK to `io.linkrunner:android-sdk:4.2.0` (TCF consent collection).
+
 ## [3.1.0] - 2026-07-29
 
 ### Added

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -116,7 +116,7 @@ dependencies {
     implementation 'com.facebook.react:react-android:0.80.0'
 
     // Linkrunner SDK 
-    implementation "io.linkrunner:android-sdk:4.1.0"
+    implementation "io.linkrunner:android-sdk:4.2.0"
 
     // Kotlin standard libraries - use stable versions
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"

--- a/android/src/main/java/io/linkrunner/LinkrunnerModule.kt
+++ b/android/src/main/java/io/linkrunner/LinkrunnerModule.kt
@@ -444,6 +444,19 @@ class LinkrunnerModule(private val reactContext: ReactApplicationContext) : Reac
     }
 
     @ReactMethod
+    fun enableTCFConsentCollection(enabled: Boolean) {
+        try {
+            linkrunnerSDK.enableTCFConsentCollection(enabled)
+
+            if (BuildConfig.DEBUG) {
+                Log.d(TAG, "Linkrunner: TCF consent collection ${if (enabled) "enabled" else "disabled"}")
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to ${if (enabled) "enable" else "disable"} TCF consent collection", e)
+        }
+    }
+
+    @ReactMethod
     fun setPushToken(pushToken: String, promise: Promise) {
         if (pushToken.isBlank()) {
             promise.reject("SET_PUSH_TOKEN_ERROR", "Push token cannot be empty")

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-linkrunner",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "React Native Package for linkrunner",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/src/index.ts
+++ b/src/index.ts
@@ -356,11 +356,11 @@ class Linkrunner {
    * Opt in rather than automatic, because interpreting a TC string on your behalf is a
    * legal judgement. Only enable it if you use a TCF-compliant CMP: custom consent
    * screens and Firebase Consent Mode do not write those keys. Not persisted, so call
-   * it on every launch before `init`. iOS only.
+   * it on every launch before `init`. Supported on iOS and Android.
    */
   enableTCFConsentCollection(enabled: boolean = true): void {
     try {
-      if (Platform.OS !== 'ios') {
+      if (Platform.OS !== 'ios' && Platform.OS !== 'android') {
         return;
       }
 


### PR DESCRIPTION
## Summary

`enableTCFConsentCollection(enabled)` now works on Android too, matching iOS. The JS API and iOS bridge shipped in 3.1.0; this PR adds the missing Android half.

- **`LinkrunnerModule.kt`**: new `@ReactMethod enableTCFConsentCollection(enabled: Boolean)` forwarding to the native SDK.
- **`src/index.ts`**: drops the iOS-only gate, so Android calls reach the native module; other platforms still return early.
- Native Android SDK bumped to `io.linkrunner:android-sdk:4.2.0` (linkrunner-labs/linkrunner-android#33), which reads the CMP's `IABTCF_*` keys from the default SharedPreferences and applies the same Google TCF purpose mapping. Explicit `setConsent` values still win, per signal.
- Package bumped to **3.2.0** with a CHANGELOG entry.

### Testing

`tsc --noEmit` is clean (also runs via the lefthook pre-commit hook). The Android module compiles against android-sdk 4.2.0 once that artifact is published.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Android support for TCF consent collection.
  * Consent settings can now be read from standard CMP preferences and mapped to Google TCF purposes.
  * Explicit consent values continue to take precedence over collected CMP values.

* **Changed**
  * Updated the package to version 3.2.0.
  * Updated the native Android SDK to support TCF consent collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->